### PR TITLE
fix(escape): handle escape char in content

### DIFF
--- a/src/main/scala/com/github/tototoshi/csv/CSVParser.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVParser.scala
@@ -246,7 +246,10 @@ object CSVParser {
                   state = QuotedField
                   pos += 2
                 } else {
-                  throw new MalformedCSVException(buf.mkString)
+                  field += buf(pos)
+                  field += buf(pos + 1)
+                  state = QuotedField
+                  pos += 2
                 }
               } else {
                 throw new MalformedCSVException(buf.mkString)

--- a/src/test/resources/backslash-content.csv
+++ b/src/test/resources/backslash-content.csv
@@ -1,0 +1,1 @@
+"field1","field2","field3 says, \o/"

--- a/src/test/scala/com/github/tototoshi/csv/CSVReaderSpec.scala
+++ b/src/test/scala/com/github/tototoshi/csv/CSVReaderSpec.scala
@@ -138,6 +138,19 @@ class CSVReaderSpec extends AnyFunSpec with Matchers with Using {
       res should be(List("field1", "field2", "field3 says, \"escaped with backslash\""))
     }
 
+    it("should read csv file whose escape char is in the content without escaping a char") {
+      var res: List[String] = Nil
+      implicit val format = new DefaultCSVFormat {
+        override val escapeChar: Char = '\\'
+      }
+      using(CSVReader.open("src/test/resources/backslash-content.csv")(format)) { reader =>
+        reader foreach { fields =>
+          res = res ++ fields
+        }
+      }
+      res should be(List("field1", "field2", raw"field3 says, \o/"))
+    }
+
     it("read simple CSV file with empty quoted fields") {
       var res: List[String] = Nil
       using(CSVReader.open("src/test/resources/issue30.csv")) { reader =>


### PR DESCRIPTION
Ignore the case where the escape char is not the quote and is used in
the content.